### PR TITLE
Allow the developer to manually accept/reject an eth_requestAccounts request

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,9 @@
         "radix": "off",
         "import/extensions": ["error", "always", {
             "ts": "never"
-        }]
+        }],
+        "no-unused-vars": "off", // ref: https://github.com/typescript-eslint/typescript-eslint/blob/b5b5f415c234f3456575a69da31ac9f6d2f8b146/packages/eslint-plugin/docs/rules/no-unused-vars.md
+        "@typescript-eslint/no-unused-vars": ["error"]
     },
     "settings": {
         "import/resolver": {
@@ -30,5 +32,5 @@
                 "extensions": [".js", ".jsx", ".ts", ".tsx"]
             }
         }
-} 
+    }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npx tsc --outDir ./dist",
     "build:watch": "npx tsc -w --outDir ./dist",
     "lint": "npx eslint ./src/*.ts",
+    "lint:fix": "npx eslint ./src/*.ts --fix",
     "test": "npx jest",
     "test:ci": "npx jest --verbose --coverage --watchAll=false --coverageDirectory reports --maxWorkers=2",
     "test:watch": "npx jest --watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/mock-web3-provider",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "repository": "git@github.com:jessgusclark/mock-web3-provider.git",
   "author": "Jesse Clark <hello@developerjesse.com>",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { MockProvider } from './index'
 
-describe('provider', () => {
+describe('default provider', () => {
   const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
   const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
@@ -69,4 +69,45 @@ describe('provider', () => {
       expect(result).toEqual('tacos')
     })
   })
+})
+
+describe('provider with confirm enable', () => {
+  const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
+  const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
+
+  const provider = new MockProvider({
+    address, privateKey, networkVersion: 31, debug: false, manualConfirmEnable: true
+  })
+
+  it('should not allow to use acceptEnable without pending request', () => {
+    expect(() => provider.answerEnable(true)).toThrow()
+    expect(() => provider.answerEnable(false)).toThrow()
+  })
+
+  it('resolves with acceptance', async () => {
+    expect.assertions(1)
+
+    const responsePromise = provider.request({ method: 'eth_requestAccounts', params: [] })
+      .then((accounts: any) => expect(accounts[0]).toEqual(address))
+
+    provider.answerEnable(true)
+    await responsePromise
+  })
+
+  it('rejects with denial', async () => {
+    expect.assertions(1)
+
+    const responsePromise = provider.request({ method: 'eth_requestAccounts', params: [] })
+      .catch(e => expect(e).toBeDefined())
+
+    provider.answerEnable(false)
+    await responsePromise
+  })
+
+  /*
+  it('does not resolver request accounts if no answer', async () => {
+    // see that this timeouts
+    await provider.request({ method: 'eth_requestAccounts', params: [] })
+  })
+  */
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,11 +1,11 @@
-import mockProvider from './index'
+import { MockProvider } from './index'
 
 describe('provider', () => {
   const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D'
   const privateKey = 'de926db3012af759b4f24b5a51ef6afa397f04670f634aa4f48d4480417007f3'
 
-  const provider = mockProvider({
-    address, privateKey, chainId: 31, debug: false
+  const provider = new MockProvider({
+    address, privateKey, networkVersion: 31, debug: false
   })
 
   it('returns a provider object', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -98,7 +98,7 @@ describe('provider with confirm enable', () => {
     expect.assertions(1)
 
     const responsePromise = provider.request({ method: 'eth_requestAccounts', params: [] })
-      .catch(e => expect(e).toBeDefined())
+      .catch((e) => expect(e).toBeDefined())
 
     provider.answerEnable(false)
     await responsePromise

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,19 @@ interface IMockProvider {
   request(args: { method: string, params?: any[] }): Promise<any>
 }
 
+// eslint-disable-next-line import/prefer-default-export
 export class MockProvider implements IMockProvider {
   private setup: ProviderSetup
 
   private acceptEnable?: (value: unknown) => void
+
   private rejectEnable?: (value: unknown) => void
 
   constructor(setup: ProviderSetup) {
     this.setup = setup
   }
 
+  // eslint-disable-next-line no-console
   private log = (...args: (any | null)[]) => this.setup.debug && console.log('🦄', ...args)
 
   get selectedAddress(): string {
@@ -61,9 +64,8 @@ export class MockProvider implements IMockProvider {
             this.acceptEnable = resolve
             this.rejectEnable = reject
           }).then(() => [this.selectedAddress])
-        } else {
-          return Promise.resolve([this.selectedAddress])
         }
+        return Promise.resolve([this.selectedAddress])
 
       case 'net_version':
         return Promise.resolve(this.setup.networkVersion)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,79 +3,94 @@ import { personalSign, decrypt } from 'eth-sig-util'
 interface ProviderSetup {
   address: string,
   privateKey: string,
-  chainId: number,
+  networkVersion: number,
   debug?: boolean
+  manualConfirmEnable?: boolean
 }
 
-const provider = (startProps: ProviderSetup) => {
-  const {
-    address, privateKey, chainId, debug
-  } = startProps
+export class MockProvider {
+  setup: ProviderSetup
 
-  /* Logging */
-  // eslint-disable-next-line no-console
-  const log = (...args: (any | null)[]) => debug && console.log('🦄', ...args)
-
-  const buildProvider = {
-    isMetaMask: true,
-    networkVersion: chainId,
-    chainId: `0x${chainId.toString(16)}`,
-    selectedAddress: address,
-
-    request(props: { method: any; params: string[] }) {
-      log(`request[${props.method}]`)
-      switch (props.method) {
-        case 'eth_requestAccounts':
-        case 'eth_accounts':
-          return Promise.resolve([this.selectedAddress])
-        case 'net_version':
-          return Promise.resolve(this.networkVersion)
-        case 'eth_chainId':
-          return Promise.resolve(this.chainId)
-
-        case 'personal_sign': {
-          const privKey = Buffer.from(privateKey, 'hex');
-          const signed = personalSign(privKey, { data: props.params[0] })
-          log('signed', signed)
-          return Promise.resolve(signed)
-        }
-        case 'eth_sendTransaction': {
-          return Promise.reject(new Error('This service can not send transactions.'))
-        }
-        case 'eth_decrypt': {
-          log('eth_decrypt', props)
-          const stripped = props.params[0].substring(2)
-          const buff = Buffer.from(stripped, 'hex');
-          const data = JSON.parse(buff.toString('utf8'));
-          return Promise.resolve(decrypt(data, privateKey))
-        }
-        default:
-          log(`resquesting missing method ${props.method}`)
-          // eslint-disable-next-line prefer-promise-reject-errors
-          return Promise.reject(`The method ${props.method} is not implemented by the mock provider.`)
-      }
-    },
-
-    sendAsync(props: { method: string }, cb: any) {
-      switch (props.method) {
-        case 'eth_accounts':
-          cb(null, { result: [this.selectedAddress] })
-          break;
-        case 'net_version': cb(null, { result: this.networkVersion })
-          break;
-        default: log(`Method '${props.method}' is not supported yet.`)
-      }
-    },
-    on(props: string) {
-      log('registering event:', props)
-    },
-    removeAllListeners() {
-      log('removeAllListeners', null)
-    },
+  constructor(setup: ProviderSetup) {
+    this.setup = setup
   }
 
-  log('Mock Provider ', buildProvider)
-  return buildProvider;
-}
+  private log = (...args: (any | null)[]) => this.setup.debug && console.log('🦄', ...args)
 
-export default provider
+  get selectedAddress() {
+    return this.setup.address
+  }
+
+  get networkVersion() {
+    return this.setup.networkVersion
+  }
+
+  get chainId() {
+    return `0x${this.setup.networkVersion.toString(16)}`
+  }
+
+  request(props: { method: any; params: string[] }) {
+    this.log(`request[${props.method}]`)
+
+    switch (props.method) {
+      case 'eth_requestAccounts':
+      case 'eth_accounts':
+        return Promise.resolve([this.setup.address])
+
+      case 'net_version':
+        return Promise.resolve(this.setup.networkVersion)
+
+      case 'eth_chainId':
+        return Promise.resolve(this.chainId)
+
+      case 'personal_sign': {
+        const privKey = Buffer.from(this.setup.privateKey, 'hex');
+        const signed = personalSign(privKey, { data: props.params[0] })
+
+        this.log('signed', signed)
+
+        return Promise.resolve(signed)
+      }
+
+      case 'eth_sendTransaction': {
+        return Promise.reject(new Error('This service can not send transactions.'))
+      }
+
+      case 'eth_decrypt': {
+        this.log('eth_decrypt', props)
+
+        const stripped = props.params[0].substring(2)
+        const buff = Buffer.from(stripped, 'hex');
+        const data = JSON.parse(buff.toString('utf8'));
+
+        return Promise.resolve(decrypt(data, this.setup.privateKey))
+      }
+
+      default:
+        this.log(`resquesting missing method ${props.method}`)
+        // eslint-disable-next-line prefer-promise-reject-errors
+        return Promise.reject(`The method ${props.method} is not implemented by the mock provider.`)
+    }
+  }
+
+  sendAsync(props: { method: string }, cb: any) {
+    switch (props.method) {
+      case 'eth_accounts':
+        cb(null, { result: [this.setup.address] })
+        break;
+
+      case 'net_version': cb(null, { result: this.setup.networkVersion })
+        break;
+
+      default: this.log(`Method '${props.method}' is not supported yet.`)
+    }
+  }
+
+  on(props: string) {
+    this.log('registering event:', props)
+  }
+
+  removeAllListeners() {
+    this.log('removeAllListeners', null)
+  }
+}


### PR DESCRIPTION
Refactor: I moved to `class` to make the `MockProvider` stateful

Added configuration: `manualConfirmEnable?: boolean`

Also changed `chainId` for `networkVersion`: it was misleading that `provider.networkVersion` returned `setup.chainId` and `provider.chainId` returned a modification of `setup.chainId`. Now developer sets `networkVersion` in the config instead of `chainId`, then `prvider.chainId` returns the correct transformation of the `networkVersion` that is set.

Added functionality: if the configuration states that developer wants to manually trigger enable (`manualConfirmEnable` is set to `true`) on `eth_requestAccounts`, then semaphore is set to allow developer to trigger `answerEnable(acceptance: boolean)`

Expected use from integration test is like:

1. Developer creates mock provider and plugs it into `window.ethereum`
2. Developer emulate sends `request({ method: 'eth_requestAccounts' })` when clicking on _login_
3. Developer can assert _loading_ is shown
4. Developer emulates user acceptance doing `provider.answerEnable(true)`
5. Developer can assert _loading_ is not shown anymore and next step received user's account

Bumped version to `v1` since this is breaking for `v0`