### PR TITLE
Add `wallet_requestPermissions` method

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -59,6 +59,21 @@ describe('default provider', function test(this: {
     })
   })
 
+  describe('wallet_requestPermissions', () => {
+    it('is correct with response', async () => {
+      Date.now = jest.fn(() => new Date(Date.UTC(2022, 1, 1)).valueOf())
+      const response = await this.provider.request({ method: 'wallet_requestPermissions', params: [{ eth_accounts: {} }] })
+
+      expect(response[0].parentCapability).toEqual('eth_accounts');
+      expect(response[0].date).toEqual(Date.now());
+    })
+
+    it('rejects if params are invalid', async () => {
+      await expect(this.provider.request({ method: 'wallet_requestPermissions', params: [] })).rejects.toThrow()
+      await expect(this.provider.request({ method: 'wallet_requestPermissions', params: [{ other_method: {} }] })).rejects.toThrow()
+    })
+  })
+
   describe('eth_chainId & net_version', () => {
     it('is correctly set', () => {
       expect(this.provider.networkVersion).toBe(31)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,15 @@ type ProviderSetup = {
   manualConfirmEnable?: boolean
 }
 
+type Web3WalletPermission = {
+  parentCapability: string;
+  date?: number;
+}
+
 interface IMockProvider {
   request(args: { method: 'eth_accounts'; params: string[] }): Promise<string[]>
   request(args: { method: 'eth_requestAccounts'; params: string[] }): Promise<string[]>
+  request(args: { method: 'wallet_requestPermissions'; params: {[methodName: string]: {}}[] }): Promise<Web3WalletPermission[]>
 
   request(args: { method: 'net_version' }): Promise<number>
   request(args: { method: 'eth_chainId'; params: string[] }): Promise<string>
@@ -68,6 +74,20 @@ export class MockProvider implements IMockProvider {
           }).then(() => [this.selectedAddress])
         }
         return Promise.resolve([this.selectedAddress])
+
+      case 'wallet_requestPermissions':
+        if (!params[0].eth_accounts)
+          return Promise.reject(`The method "${Object.keys(params[0])[0]}" does not exist / is not available`)
+
+        const permissions: Web3WalletPermission[] = [{ parentCapability: 'eth_accounts', date: Date.now() }]
+
+        if (this.setup.manualConfirmEnable) {
+          return new Promise((resolve, reject) => {
+            this.acceptEnable = resolve
+            this.rejectEnable = reject
+          }).then(() => permissions)
+        }
+        return Promise.resolve(permissions)
 
       case 'net_version':
         return Promise.resolve(this.setup.networkVersion)

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,9 +75,10 @@ export class MockProvider implements IMockProvider {
         }
         return Promise.resolve([this.selectedAddress])
 
-      case 'wallet_requestPermissions':
-        if (!params[0].eth_accounts)
-          return Promise.reject(`The method "${Object.keys(params[0])[0]}" does not exist / is not available`)
+      case 'wallet_requestPermissions': {
+        if (!params[0]) return Promise.reject(new Error('Invalid method parameter(s).'))
+
+        if (!params[0].eth_accounts) return Promise.reject(new Error(`The method "${Object.keys(params[0])[0]}" does not exist / is not available.`))
 
         const permissions: Web3WalletPermission[] = [{ parentCapability: 'eth_accounts', date: Date.now() }]
 
@@ -88,6 +89,7 @@ export class MockProvider implements IMockProvider {
           }).then(() => permissions)
         }
         return Promise.resolve(permissions)
+      }
 
       case 'net_version':
         return Promise.resolve(this.setup.networkVersion)


### PR DESCRIPTION
Was implemented following the standards from [RPC API | MetaMask Docs](https://docs.metamask.io/guide/rpc-api.html#wallet-requestpermissions) and [EIP-2255: Wallet Permissions System](https://eips.ethereum.org/EIPS/eip-2255)